### PR TITLE
handle CTRL-C as a way to exit the program

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -126,6 +126,12 @@ class Gui(EventHandler):
 
     def handle_keyboard(self, event_data):
         logger.info("Key Pressed : {}".format(event_data.key))
+
+        # check if we got a CTRL-C
+        if ord(event_data.key) == 3:
+            self.quit()
+            return
+
         if event_data.key == "s":
             # imitate start/finish behavior
             self.app.children[2].hide()


### PR DESCRIPTION
Fix #37

We need to handle CTRL-C to exit since we're having power trouble and won't be able to run a touch screen