### PR TITLE
Fix 45

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -126,6 +126,12 @@ class Gui(EventHandler):
 
     def handle_keyboard(self, event_data):
         logger.info("Key Pressed : {}".format(event_data.key))
+
+        # check if we got a CTRL-C
+        if ord(event_data.key) == 3:
+            self.quit()
+            return
+
         if event_data.key == "s":
             # imitate start/finish behavior
             self.app.children[2].hide()

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from display_providers import LocalTimeProvider
 from track import TrackLocation, read_tracks
 from state_machine import StateMachine
 from movement_listener import MovementListener
+from usb_detector import UsbDetector
 from haversine import haversine
 import logging
 from logging.handlers import RotatingFileHandler
@@ -57,6 +58,8 @@ state_machine = StateMachine()
 movement_listener = MovementListener()
 
 gui = Gui()
+
+UsbDetector.init()
 
 MA = MafAnalyzer(lap_logger)
 

--- a/obd_reader.py
+++ b/obd_reader.py
@@ -8,6 +8,7 @@ from threading import Thread
 from display_providers import TemperatureProvider
 from updaters import FuelUsageUpdater
 from events import OBDConnectedEvent, OBDDisconnectedEvent, ExitApplicationEvent
+from usb_detector import UsbDetector, UsbDevice
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +53,7 @@ class ObdReader(Thread, TemperatureProvider):
             try:
                 connection = self.connect()
                 if connection is None:
-                    time.sleep(10)
+                    time.sleep(30)
                     continue
 
                 while connection.status() == obd.OBDStatus.CAR_CONNECTED and not self.finished:
@@ -73,22 +74,17 @@ class ObdReader(Thread, TemperatureProvider):
                 time.sleep(10)
 
     def connect(self):
-        ports = obd.scan_serial()
-        usb = ""
-        logger.info("ports = " + str(ports))
-        for port in ports:
-            if self.is_rpi:
-                if port.find('USB0'):
-                    usb = port
-            else:  # mac / darwin
-                if port.find('usbserial') > 0:
-                    usb = port
-        if usb == "":
+        port = UsbDetector.get(UsbDevice.OBD)
+        if not port:
             return None
 
-        result = obd.OBD(usb, protocol="3")
+        result = obd.OBD(port, protocol="3")
+        status = result.status()
+        if status == obd.OBDStatus.NOT_CONNECTED or \
+           status == obd.OBDStatus.ELM_CONNECTED:
+            result.close()
+            return None
         OBDConnectedEvent.emit()
-        # result.print_commands()
 
         cmds = result.query(obd.commands.PIDS_A)
         logger.debug("available PIDS_A commands {}".format(cmds.value))
@@ -142,5 +138,6 @@ if __name__ == "__main__":
         def update_fuel(self, ml_per_second:float, time:float):
             print("Fuel: {:.2f} ml per sec".format(ml_per_second))
 
+    UsbDetector.init()
     ObdReader(OBDLogger()).run()
 

--- a/usb_detector.py
+++ b/usb_detector.py
@@ -1,0 +1,116 @@
+
+import platform
+import glob
+import os
+import logging
+import serial
+import time
+from enum import Enum
+import obd
+from obd import OBDStatus
+
+logger = logging.getLogger(__name__)
+
+
+class UsbDevice(Enum):
+    OBD = 1
+    LORA = 2
+
+
+# it's hard to tell which device is plugged into the computer ... either on
+# Raspian or on Mac.
+#
+# This class attempts to solve this by scanning the serial ports that appear to be
+# candidates and then querying the interface to try to figure out what is what
+class UsbDetector:
+
+    __instance = None
+
+    def __init__(self):
+        self.usb_map : dict[UsbDevice, str] = {}
+        self.device_map : dict[str, UsbDevice] = {}
+        self.last_scan_time = 0
+
+    @classmethod
+    def init(cls):
+        UsbDetector.__instance = UsbDetector()
+        UsbDetector.__instance.__scan__()
+
+    @classmethod
+    def get_instance(cls):
+        return UsbDetector.__instance
+
+    @classmethod
+    def get(cls, device_type:UsbDevice):
+        return UsbDetector.__instance.usb_map[device_type]
+
+    def __scan__(self):
+        glob_pattern = self.__get_dev_pattern__()
+        devices = glob.glob(glob_pattern)
+        logger.info("found usb serial devices : {}".format(devices))
+
+        # step 0 ... throw out already classified
+        for device in devices:
+            if os.path.getctime(device) < self.last_scan_time:
+                logger.info("already mapped : {}".format(device))
+                devices.remove(device)
+
+        # step1 ... see if any are radio
+        logger.info("detecting Lora devices")
+        for device in devices:
+            with serial.Serial(device, baudrate=57600, timeout=2) as ser:
+                try:
+                    while len(ser.readline()):
+                        logger.debug("throwing away... ")
+                        pass
+                    ser.write("sys get ver\r\n".encode("UTF-8"))
+                    time.sleep(0.5)
+                    # set timeout ...? ?
+                    resp_bytes = ser.readline()
+                    logger.info(resp_bytes)
+                    if resp_bytes:
+                        resp = resp_bytes.decode("UTF-8")
+                        if resp.startswith("RN2903"):
+                            self.usb_map[UsbDevice.LORA] = device
+                            self.device_map[device] = UsbDevice.LORA
+                            logger.info("associated {} with Lora".format(device))
+
+                except UnicodeDecodeError:
+                    # we get into this when we try to talk to OBD like this
+                    pass
+                finally:
+                    ser.close()
+
+        logger.info("detecting OBD devices")
+        for device in devices:
+            if self.device_map.get(device):
+                # it's been identified as Lora
+                continue
+            try:
+                obd_scanner = obd.OBD(portstr=device)
+                if obd_scanner.status() != OBDStatus.NOT_CONNECTED:
+                    self.usb_map[UsbDevice.OBD] = device
+                    self.device_map[device] = UsbDevice.OBD
+                    logger.info("associated {} with OBD".format(device))
+                obd_scanner.close()
+            except:
+                logger.info("ok, so it's not OBD")
+
+        self.last_scan_time = time.time()
+
+
+
+    def __get_dev_pattern__(self):
+        if platform.system() == "Linux":
+            return "/dev/ttyUSB*"
+        else:
+            return "/dev/tty.usbserial*"
+
+
+if __name__ == "__main__":
+
+    logging.basicConfig(format='%(asctime)s %(name)s %(message)s',
+                        datefmt='%Y-%m-%d %H:%M:%S',
+                        level=logging.INFO)
+
+    UsbDetector.init()


### PR DESCRIPTION
detect whether USB0/USB1 are connected to the Lora or the OBD device

I ended up creating a singleton instance for this, which made initialization timing easier.

Since this detection takes a few seconds, we might want to think about doing all this while the splash screen is showing...but that will be a mildy yucky rework of the initialization logic so I'll file another ticket for that