### PR TITLE
fixes initialization timing on the radio mechanism 

### DIFF
--- a/shared/message_decoder.py
+++ b/shared/message_decoder.py
@@ -33,9 +33,14 @@ class MessageDecoder:
             payload = self.__do_decrypt(encrypted_payload)
             instance.ParseFromString(payload)
             return instance
+        except RuntimeWarning:
+            # this means the protobuf was wrong
+            raise LPiNoiseException()
         except ValueError:
+            # this means the decryption failed
             raise LPiNoiseException()
         except DecodeError:
+            # another protobuf error we may see
             raise LPiNoiseException()
 
     def __do_decrypt(self, encrypted_payload):

--- a/utils/send_driver_message.py
+++ b/utils/send_driver_message.py
@@ -1,0 +1,32 @@
+
+import os
+import logging
+import time
+from python_settings import settings
+
+from shared.generated.messages_pb2 import DriverMessage
+from shared.radio import Radio
+from shared.usb_detector import UsbDetector
+
+logger = logging.getLogger(__name__)
+
+logging.basicConfig(format='%(asctime)s %(name)s %(message)s',
+                    datefmt='%Y-%m-%d %H:%M:%S',
+                    level=logging.INFO)
+
+if not "SETTINGS_MODULE" in os.environ:
+    os.environ["SETTINGS_MODULE"] = "config.settings-pit"
+
+UsbDetector().init()
+
+radio = Radio(settings.RADIO_DEVICE, settings.RADIO_KEY)
+radio.start()
+
+msg = DriverMessage()
+msg.text = "Get yer arse into gear!"
+
+radio.send_async(msg)
+
+logger.info("sleeping to give transmission enough time")
+time.sleep(5)
+logger.info("finished")


### PR DESCRIPTION
It does this by awaiting an expected response from the last initialization command before starting up the send thread.

this also fixes the timing of the light on/off logic which was trying to run without any delays ... that doesn't work. Everything needs delays. On the mac a delay of 0.2 and 0.1 have been tested and appear fine.