### PR TITLE
Radio sync point

### DIFF
--- a/car/events.py
+++ b/car/events.py
@@ -55,6 +55,9 @@ CompleteLapEvent = Event("CompleteLap")
 # a request to exit the application
 ExitApplicationEvent = Event("ExitApplication")
 
+# the car should transmit status on radio
+RadioSyncEvent = Event("RadioSync")
+
 ### State Change Events
 
 # the car is setting off from pits

--- a/car/track.py
+++ b/car/track.py
@@ -48,7 +48,7 @@ class TrackLocation:
 
     def set_radio_sync_coords(self, lat_long1, lat_long2, direction):
         self.radio_sync = Target("radio-sync", lat_long1, lat_long2, direction)
-        logger.debug("{} : radio-sync heading = {}".format(self.name, int(self.pit_in.target_heading)))
+        logger.debug("{} : radio-sync heading = {}".format(self.name, int(self.radio_sync.target_heading)))
 
     def __repr__(self):
         return self.name
@@ -80,4 +80,9 @@ def read_tracks() -> [TrackLocation]:
     return track_list
 
 if __name__ == "__main__":
+
+    logging.basicConfig(format='%(asctime)s %(name)s %(message)s',
+                        datefmt='%Y-%m-%d %H:%M:%S',
+                        level=logging.DEBUG)
+
     read_tracks()

--- a/car/track.py
+++ b/car/track.py
@@ -16,6 +16,7 @@ class TrackLocation:
         start_finish_end = (lat2, long2)
         self.start_finish:Target = Target("start/finish", start_finish_begin, start_finish_end, dir)
         self.pit_in:Target = None
+        self.radio_sync:Target = None
 
         logger.debug("{} : width = {} heading = {}".format(name, self.track_width_feet(),
                                                     int(self.start_finish.target_heading)))
@@ -39,6 +40,16 @@ class TrackLocation:
         self.pit_in = Target("pit-in", lat_long1, lat_long2, direction)
         logger.debug("{} : pit-in heading = {}".format(self.name, int(self.pit_in.target_heading)))
 
+    def is_radio_sync_defined(self) -> bool:
+        return self.radio_sync is not None
+
+    def get_radio_sync_target(self) -> Target:
+        return self.radio_sync
+
+    def set_radio_sync_coords(self, lat_long1, lat_long2, direction):
+        self.radio_sync = Target("radio-sync", lat_long1, lat_long2, direction)
+        logger.debug("{} : radio-sync heading = {}".format(self.name, int(self.pit_in.target_heading)))
+
     def __repr__(self):
         return self.name
 
@@ -59,6 +70,12 @@ def read_tracks() -> [TrackLocation]:
                 assert len(points) == 4, "expected 4 points"
                 track_data.set_pit_in_coords((float(points[0]), float(points[1])),
                                              (float(points[2]), float(points[3])), track["pit_entry_direction"])
+            if "radio_sync_coords" in track:
+                pi = track["radio_sync_coords"]
+                points = re.findall("[-+]?\d+.\d+", pi)
+                assert len(points) == 4, "expected 4 points"
+                track_data.set_radio_sync_coords((float(points[0]), float(points[1])),
+                                             (float(points[2]), float(points[3])), track["radio_sync_direction"])
             track_list.append(track_data)
     return track_list
 

--- a/resources/tracks.yaml
+++ b/resources/tracks.yaml
@@ -30,5 +30,7 @@ tracks:
      start_finish_direction: "SE"
      pit_entry_coords: "(37.928483,-122.297005),(37.928385,-122.297129)"
      pit_entry_direction: "NW"
+     radio_sync_coords: "(37.927488,-122.296294),(37.927402,-122.296196)"
+     radio_sync_direction: "NE"
 
 

--- a/shared/protos/messages.proto
+++ b/shared/protos/messages.proto
@@ -96,3 +96,13 @@ message CarTelemetry {
   int32 fuel_remaining_percent = 8;
 }
 
+message EnteringPits {
+
+  int32 seq_num = 1;
+
+  int32 timestamp = 2;
+
+  string sender = 3;
+
+}
+


### PR DESCRIPTION
adds an optional point on the track where the car should transmit its telemetry data.
it always does this on the start/finish line, but sometimes that point may be radio blind.

also adds a protobuf definition for an entering pits message, and this wires up that too.