### PR TITLE
Handle messages from pit in car

### DIFF
--- a/car/events.py
+++ b/car/events.py
@@ -3,6 +3,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 # a simple event framework so we can connect together decoupled logic
 class EventHandler:
 
@@ -16,8 +17,10 @@ class Event:
     last_event = None
     last_event_count = 0
 
-    def __init__(self, name=""):
+    def __init__(self, name="", suppress_logs=False):
         self.name = name
+        # some events emit all the time so we suppress logging them consecutively
+        self.suppress_logs = suppress_logs
         self.handlers = []
 
     def register_handler(self, handler:EventHandler):
@@ -27,7 +30,7 @@ class Event:
             logger.error("{} attempted to register same handler twice {}", self.name, handler.__class__)
 
     def emit(self, **kwargs):
-        if self == Event.last_event:
+        if self == Event.last_event and self.suppress_logs:
             Event.last_event_count += 1
         else:
             if Event.last_event_count > 0:
@@ -41,10 +44,10 @@ class Event:
 
 
 # the car is moving
-MovingEvent = Event("Moving")
+MovingEvent = Event("Moving", suppress_logs=True)
 
 # the car is not moving
-NotMovingEvent = Event("NotMoving")
+NotMovingEvent = Event("NotMoving", suppress_logs=True)
 
 # the car is exiting the race track and entering the pits
 LeaveTrackEvent = Event("LeaveTrack")
@@ -78,7 +81,21 @@ GPSDisconnectedEvent = Event("GPS-Disconnected")
 RefuelEvent = Event("Refuel")
 
 ### Car has come to a halt
-CarStoppedEvent = Event("CarStopped")
+CarStoppedEvent = Event("CarStopped", suppress_logs=True)
 
+########## Incoming Radio Events
+
+# emit() will contain
+#   text=
+#   duration_secs=
+DriverMessageEvent = Event("driver-message")
+
+# emit() will contain
+#   text=
+DriverMessageAddendumEvent = Event("driver-message-addendum")
+
+# emit() will contain
+#   flag=(GREEN|YELLOW|RED|BLACK|UNKNOWN)
+RaceFlagStatusEvent = Event("flag-status")
 
 

--- a/car/gui.py
+++ b/car/gui.py
@@ -48,36 +48,35 @@ class Gui(EventHandler):
 
         # this is our lower text area
         self.lower_row = Box(self.app, align="bottom", width=Gui.WIDTH, height=64)
-        self.lower_row.bg = "purple"
-        self.msg_area = Text(self.lower_row, "P13   ▲ 2 by 35s   ▼ 56 by 2 laps", align="left", size=48, font=self.font, color="white")
+        self.msg_area = Text(self.lower_row, "", align="left", size=48, font=self.font, color="white", bg="purple")
 
-        col1 = Box(self.app, align="left", width=Gui.COL_WIDTH, height=Gui.HEIGHT - 100)
-        col2 = Box(self.app, align="left", width=Gui.COL_WIDTH, height=Gui.HEIGHT - 100)
-        col3 = Box(self.app, align="left", width=Gui.COL_WIDTH, height=Gui.HEIGHT - 100)
+        self.col1 = Box(self.app, align="left", width=Gui.COL_WIDTH, height=Gui.HEIGHT - 100)
+        self.col2 = Box(self.app, align="left", width=Gui.COL_WIDTH, height=Gui.HEIGHT - 100)
+        self.col3 = Box(self.app, align="left", width=Gui.COL_WIDTH, height=Gui.HEIGHT - 100)
 
         # these are invisible displays used to show special case data when the car is pitting
-        col4 = Box(self.app, align="left", width=col3.width, height=col3.height, visible=False)
-        col5 = Box(self.app, align="left", width=col3.width, height=col3.height, visible=False)
+        self.col4 = Box(self.app, align="left", width=self.col3.width, height=self.col3.height, visible=False)
+        self.col5 = Box(self.app, align="left", width=self.col3.width, height=self.col3.height, visible=False)
 
-        self.time_widget = self.create_time_widget(col1)
-        Box(col1, height=24, width=208)
-        self.lap_display = self.create_lap_widget(col1)
-        Box(col2, height=24, width=208)
-        self.temp_widget = self.create_temp_widget(col2)
-        Box(col2, height=24, width=208)
-        self.speed_heading_widget = self.create_speed_widget(col2)
-        self.fuel_display = self.create_fuel_widget(col3)
+        self.time_widget = self.create_time_widget(self.col1)
+        Box(self.col1, height=24, width=208)
+        self.lap_display = self.create_lap_widget(self.col1)
+        Box(self.col2, height=24, width=208)
+        self.temp_widget = self.create_temp_widget(self.col2)
+        Box(self.col2, height=24, width=208)
+        self.speed_heading_widget = self.create_speed_widget(self.col2)
+        self.fuel_display = self.create_fuel_widget(self.col3)
 
-        Box(col2, height=24, width=208)
+        Box(self.col2, height=24, width=208)
 
         # adding obd + gps images
-        (self.gps_image, self.obd_image) = self.create_gps_obd_images(col2)
+        (self.gps_image, self.obd_image) = self.create_gps_obd_images(self.col2)
         # add a quit button
-        pb = PushButton(col2, image="resources/images/exitbutton.gif", command=self.quit)
-        Box(col2, height=24, width=208)
+        pb = PushButton(self.col2, image="resources/images/exitbutton.gif", command=self.quit)
+        Box(self.col2, height=24, width=208)
 
-        self.stint_ending_display = self.create_stint_end_instructions(col4)
-        self.stint_starting_display = self.create_stint_start_instructions(col5)
+        self.stint_ending_display = self.create_stint_end_instructions(self.col4)
+        self.stint_starting_display = self.create_stint_start_instructions(self.col5)
 
         LeaveTrackEvent.register_handler(self)
         StateChangePittedEvent.register_handler(self)
@@ -108,19 +107,19 @@ class Gui(EventHandler):
 
     def handle_event(self, event, **kwargs):
         if event == LeaveTrackEvent:
-            self.app.children[2].hide()
-            self.app.children[3].show()
-            self.app.children[4].hide()
+            self.col3.hide()
+            self.col4.show()
+            self.col5.hide()
             return
         if event == StateChangePittedEvent:
-            self.app.children[2].hide()
-            self.app.children[3].hide()
-            self.app.children[4].show()
+            self.col3.hide()
+            self.col4.hide()
+            self.col5.show()
             return
         if event == StateChangeSettingOffEvent:
-            self.app.children[2].show()
-            self.app.children[3].hide()
-            self.app.children[4].hide()
+            self.col3.show()
+            self.col4.hide()
+            self.col5.hide()
             return
 
         if event == RaceFlagStatusEvent:
@@ -155,10 +154,10 @@ class Gui(EventHandler):
             return
 
         # go back to the fuel display if we complete a lap and it is not showing.
-        if event == CompleteLapEvent and not self.app.children[2].visible:
-            self.app.children[2].show()
-            self.app.children[3].hide()
-            self.app.children[4].hide()
+        if event == CompleteLapEvent and not self.col3.visible:
+            self.col3.show()
+            self.col4.hide()
+            self.col5.hide()
             return
 
         if event == OBDConnectedEvent:
@@ -187,17 +186,17 @@ class Gui(EventHandler):
 
         if event_data.key == "s":
             # imitate start/finish behavior
-            self.app.children[2].hide()
-            self.app.children[3].show()
-            self.app.children[4].hide()
+            self.col3.hide()
+            self.col4.show()
+            self.col5.hide()
         if event_data.key == "f":
-            self.app.children[2].hide()
-            self.app.children[3].hide()
-            self.app.children[4].show()
+            self.col3.hide()
+            self.col4.hide()
+            self.col5.show()
         if event_data.key == "h":
-            self.app.children[2].show()
-            self.app.children[3].hide()
-            self.app.children[4].hide()
+            self.col3.show()
+            self.col4.hide()
+            self.col5.hide()
         if event_data.key == 'g':
             self.gps_image.on()
         if event_data.key == 'G':

--- a/car/radio_interface.py
+++ b/car/radio_interface.py
@@ -69,10 +69,13 @@ class RadioInterface(Thread, EventHandler):
             self.radio.send_async(EnteringPits())
 
     def run(self):
-        msg = self.radio.receive_queue.get()
-        if msg:
-            self.process_incoming(msg)
-            self.radio.receive_queue.task_done()
+        while True:
+            try:
+                msg = self.radio.receive_queue.get()
+                self.process_incoming(msg)
+                self.radio.receive_queue.task_done()
+            except Exception:
+                logger.exception("got an exception in radio_interface")
 
     def process_incoming(self, msg):
         if type(msg) == RaceStatus:

--- a/car/radio_interface.py
+++ b/car/radio_interface.py
@@ -96,7 +96,7 @@ class RadioInterface(Thread, EventHandler):
             logger.info("got race position message...{}".format(msg))
             # is this about us directly?
             if msg.car_number == settings.CAR_NUMBER:
-                if msg.car_ahead:
+                if msg.car_ahead.car_number:
                     text = "P{} ▲ {} by {}".format(msg.position, msg.car_ahead.car_number, msg.car_ahead.gap_text)
                     DriverMessageEvent.emit(text=text, duration_secs=120)
                 else:

--- a/car/radio_interface.py
+++ b/car/radio_interface.py
@@ -107,7 +107,7 @@ class RadioInterface(Thread, EventHandler):
                 # this might be the following car behind us ... it might also be for a different car in our team
                 if msg.car_ahead and msg.car_ahead.car_number == settings.CAR_NUMBER:
                     text = " ▼ {} by {}".format(msg.car_number, msg.car_ahead.gap_text)
-                    DriverMessageAddendumEvent.emit(text)
+                    DriverMessageAddendumEvent.emit(text=text)
             # TODO : we should really update the lap counter on the dash with the actual lap count from the
             # pit message
         else:

--- a/car/radio_interface.py
+++ b/car/radio_interface.py
@@ -82,11 +82,11 @@ class RadioInterface(Thread, EventHandler):
             logger.info("got race status message...{}".format(msg))
             RaceFlagStatusEvent.emit(flag=RaceStatus.RaceFlagStatus.Name(msg.flagStatus))
             if msg.flagStatus == RaceStatus.RED:
-                DriverMessageEvent.emit(text="Race Red Flagged", duration_seconds=10)
+                DriverMessageEvent.emit(text="Race Red Flagged", duration_secs=10)
             if msg.flagStatus == RaceStatus.BLACK:
-                DriverMessageEvent.emit(text="Race Black Flagged", duration_seconds=10)
+                DriverMessageEvent.emit(text="Race Black Flagged", duration_secs=10)
             if msg.flagStatus == RaceStatus.YELLOW:
-                DriverMessageEvent.emit(text="Course Yellow", duration_seconds=10)
+                DriverMessageEvent.emit(text="Course Yellow", duration_secs=10)
         elif type(msg) == DriverMessage:
             logger.info("got race driver message...{}".format(msg))
             DriverMessageEvent.emit(text=msg.text, duration_secs=30)

--- a/config/settings-car.py
+++ b/config/settings-car.py
@@ -9,15 +9,15 @@ FUEL_CAPACITY_US_GALLONS = 17.5
 # and the pit
 RADIO_KEY = "abracadabra"
 
-# set this to the team name or your car number in the car
-# it identifies the sender within this radio group
-RADIO_DEVICE = "car"
+# your car number is used for identifying your radio device
+# as well as working out which messages are for this car
+RADIO_DEVICE = CAR_NUMBER = "181"
 
 # optionally disable OBD
 OBD_DISABLED = True
 
 # optionally disable Radio
-RADIO_DISABLED = False
+RADIO_DISABLED = True
 
 # optionally disable GPS
 GPS_DISABLED = True

--- a/pit/main.py
+++ b/pit/main.py
@@ -47,15 +47,10 @@ def run():
         gui.progress(40)
 
         # start the radio thread
-        try:
-            with Radio(settings.RADIO_DEVICE, settings.RADIO_KEY) as radio:
-                RadioInterface(radio)
-                radio.start()
-                gui.progress(70)
-        except KeyError:
-            print("LORA radio not connected")
-            gui.shutdown()
-            sys.exit(1)
+        radio = Radio(settings.RADIO_DEVICE, settings.RADIO_KEY)
+        RadioInterface(radio)
+        radio.start()
+        gui.progress(85)
 
         # if we have a race specified
         if settings.RACE_ID != "":

--- a/utils/send_flag.py
+++ b/utils/send_flag.py
@@ -1,0 +1,37 @@
+
+import os
+import sys
+import logging
+import time
+from python_settings import settings
+
+from shared.generated.messages_pb2 import RaceStatus
+from shared.radio import Radio
+from shared.usb_detector import UsbDetector
+
+logger = logging.getLogger(__name__)
+
+logging.basicConfig(format='%(asctime)s %(name)s %(message)s',
+                    datefmt='%Y-%m-%d %H:%M:%S',
+                    level=logging.INFO)
+
+if not "SETTINGS_MODULE" in os.environ:
+    os.environ["SETTINGS_MODULE"] = "config.settings-pit"
+
+if len(sys.argv) != 2:
+    print("usage : {} [green|red|yellow|black]".format(__file__))
+    sys.exit(1)
+
+UsbDetector().init()
+
+radio = Radio(settings.RADIO_DEVICE, settings.RADIO_KEY)
+radio.start()
+
+msg = RaceStatus()
+msg.flagStatus = RaceStatus.RaceFlagStatus.Value(sys.argv[1].upper())
+
+radio.send_async(msg)
+
+logger.info("sleeping to give transmission enough time")
+time.sleep(5)
+logger.info("finished")

--- a/utils/send_race_pos.py
+++ b/utils/send_race_pos.py
@@ -1,0 +1,61 @@
+
+import os
+import sys
+import logging
+import time
+from python_settings import settings
+
+from shared.generated.messages_pb2 import RacePosition
+from shared.radio import Radio
+from shared.usb_detector import UsbDetector
+
+logger = logging.getLogger(__name__)
+
+logging.basicConfig(format='%(asctime)s %(name)s %(message)s',
+                    datefmt='%Y-%m-%d %H:%M:%S',
+                    level=logging.INFO)
+
+if not "SETTINGS_MODULE" in os.environ:
+    os.environ["SETTINGS_MODULE"] = "config.settings-pit"
+
+if len(sys.argv) != 3:
+    print("usage : {} [car-number] [1-3]".format(__file__))
+    print("  e.g. {} 181 2".format(__file__))
+    sys.exit(1)
+
+car_number = sys.argv[1]
+choice = int(sys.argv[2])
+
+def build_message(choice):
+    msg = RacePosition()
+    if choice == 1:
+        msg.car_number = car_number
+        msg.position = 1
+        msg.lap_count = 12
+    if choice == 2:
+        msg.car_number = car_number
+        msg.position = 2
+        msg.lap_count = 13
+        msg.car_ahead.car_number = "9"
+        msg.car_ahead.gap_text = "1:15s"
+    if choice == 3:
+        msg.car_number = "55"
+        msg.position = 3
+        msg.lap_count = 13
+        msg.car_ahead.car_number = car_number
+        msg.car_ahead.gap_text = "5s"
+    else:
+        Exception("not a valid choice")
+    return msg
+
+
+UsbDetector().init()
+
+radio = Radio(settings.RADIO_DEVICE, settings.RADIO_KEY)
+radio.start()
+radio.send_async(build_message(choice))
+
+logger.info("sleeping to give transmission enough time")
+time.sleep(5)
+logger.info("finished")
+


### PR DESCRIPTION
wires up the lemon-pi in car application to over the radio
messages.

The GUI is tightened up vertically with some less useful bits removed.

![image](https://user-images.githubusercontent.com/1510428/105623547-6dff6680-5dcf-11eb-8476-f494498a6948.png)


A lower line is added to display general messages as well as position information.

The lower line is used for general messages to the driver as well as displaying the current position and the gap to the car ahead and the car behind.

One interesting aspect is that we get a radio message near the time we cross the line which indicates our position, who is ahead and the gap. However, we do not know the gap the car behind until they cross the line.  Rather than wait for that to happen, we emit separate messages from the pits for each of these events.

The sequencing of this means that the first part of the message will fill in first, and then a bit later on the second part of the message will appear.

Don't worry about the yucky purple ... the purple background flashes up for 3 seconds then reverts to black. This should catch the eye.

Messages (including race position info) disappear after a configured period of time.
For driver messages this is 30 seconds.
For race position it is currently set to 2 minutes.

Also does some housekeeping of the event class in preparation for being able to move it into shared, and then just keep event definitions in the different applications.