### PR TITLE
sim fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ secrets.py
 mymap.html
 python-OBD
 shared/generated
+config/local_*

--- a/car/event_defs.py
+++ b/car/event_defs.py
@@ -58,6 +58,7 @@ RaceFlagStatusEvent = Event("flag-status")
 
 # emit() will contain
 #   lap_count=
+#   ts=
 LapInfoEvent = Event("lap-info")
 
 

--- a/car/gui.py
+++ b/car/gui.py
@@ -143,6 +143,7 @@ class Gui(EventHandler):
                 logger.warning("unknown flag state : {}".format(flag))
 
         if event == DriverMessageEvent:
+            self.msg_area.text_size = 48
             self.msg_area.value = kwargs.get("text")
             duration_secs = kwargs.get("duration_secs")
             self.msg_area.bg = "purple"
@@ -156,6 +157,7 @@ class Gui(EventHandler):
         # when the car behind us crosses the line we get an update on the time
         # between them and us, so we add this to the message on show
         if event == DriverMessageAddendumEvent:
+            self.msg_area.text_size = 32
             self.msg_area.value = self.msg_area.value + kwargs.get("text")
             return
 

--- a/car/movement_listener.py
+++ b/car/movement_listener.py
@@ -1,5 +1,5 @@
 
-from car.events import MovingEvent, NotMovingEvent, CarStoppedEvent
+from car.event_defs import MovingEvent, NotMovingEvent, CarStoppedEvent
 from shared.events import EventHandler
 from haversine import haversine, Unit
 import logging

--- a/car/radio_interface.py
+++ b/car/radio_interface.py
@@ -104,7 +104,7 @@ class RadioInterface(Thread, EventHandler):
                     # we're in the lead, there's no-one ahead
                     text = "P1"
                     DriverMessageEvent.emit(text=text, duration_secs=120)
-                LapInfoEvent.emit(lap_count=msg.lap_count)
+                LapInfoEvent.emit(lap_count=msg.lap_count, ts=msg.ts)
             else:
                 # this might be the following car behind us ... it might also be for a different car in our team
                 if msg.car_ahead and msg.car_ahead.car_number == settings.CAR_NUMBER:

--- a/shared/radio.py
+++ b/shared/radio.py
@@ -218,6 +218,10 @@ class Radio(Thread):
             msg = self.send_queue.get()
             self.send_message(self.protocol, msg)
             self.send_queue.task_done()
+            logger.info("awaiting TX completion")
+            while self.protocol.transmitting:
+                time.sleep(0.1)
+            logger.info("TX complete")
 
     def send_message(self, protocol, msg:Message):
         logger.debug("turning off receive")

--- a/utils/sim_race.py
+++ b/utils/sim_race.py
@@ -1,5 +1,5 @@
 import os
-from threading import Thread
+import logging
 
 from pit.datasource.datasource_handler import DataSourceHandler
 from pit.leaderboard import RaceOrder
@@ -12,6 +12,11 @@ from pit.radio_interface import RadioInterface
 from shared.radio import Radio
 from shared.usb_detector import UsbDetector
 
+logger = logging.getLogger(__name__)
+
+logging.basicConfig(format='%(asctime)s %(name)s %(message)s',
+                    datefmt='%Y-%m-%d %H:%M:%S',
+                    level=logging.INFO)
 
 def sim_race(file, handler:DataSourceHandler, time_factor):
     simtime = 0
@@ -57,4 +62,4 @@ if __name__ == "__main__":
     leaderboard = RaceOrder()
 
     handler = DataSourceHandler(leaderboard, "444")
-    sim_race("../resources/test/test-file.dat", handler, 10)
+    sim_race("../resources/test/test-file.dat", handler, 5)


### PR DESCRIPTION
in Car
 + shows a rough lap time when running in sim mode
 + reduces size of text in driver message when displaying following car gap
 + prevents hugs number showing for lap time by setting initial lap start time to now rather than 0
 + fixes import error in movement_listener.py

in Pit
 + sequences radio TX so close transmits do not tread on each other

in Sim-Race
 + adds logging

General
  + adds local config files into gitignore