### PR TITLE
image magic

### DIFF
--- a/.github/workflows/publish-tracks.yml
+++ b/.github/workflows/publish-tracks.yml
@@ -52,11 +52,16 @@ jobs:
         run: |
           echo "generating thumbnails"
           pip install pyppeteer
+          python lemon_pi/utils/html_to_image.py `ls tracks/*.html`
           for x in tracks/*.html ; do
-            python lemon_pi/utils/html_to_image.py $x
+            image=`echo $x | sed 's/\.html/\.jpg/'`
+            python lemon_pi/utils/image_crop.py $image
           done
           mkdir tracks/thumbnails
-          mv tracks/*.jpg tracks/thumbnails
+          for x in tracks/*-clipped.jpg ; do
+            target=`echo $x | sed 's/-clipped//'`
+            mv $x tracks/thumbnails/`basename $target`
+          done
 
       - id: upload-images
         if: steps.generate.outcome == 'success'
@@ -77,11 +82,10 @@ jobs:
           for x in tracks/*.html ; do
             img=`echo $x | sed -e 's/.html/.jpg/' -e 's/tracks/thumbnails/'`
             name=`grep "<title>" $x | sed -e 's/<title>//' -e 's/<\/title>//'`
-            # do not include hidden tracks in the public index
             if [[ $name != *_ ]] ; then
               echo '' >> README-tracks.tmp.md
               echo '# '"$name" >> README-tracks.tmp.md
-              echo '![]('${urlbase}/${img}')' >> README-tracks.tmp.md
+              echo '<a href='"${urlbase}/${x}"'><img src='"${urlbase}/${img}"'></a>' >> README-tracks.tmp.md
               echo '' >> README-tracks.tmp.md
               echo '[Zoomable map]('${urlbase}/${x}')' >> README-tracks.tmp.md
               echo '' >> README-tracks.tmp.md

--- a/README-dev.md
+++ b/README-dev.md
@@ -66,6 +66,10 @@ By default the car will transmit to the pits each time it crosses the start/fini
 
 The car automatically selects the closest track when the raspberry pi in-car application boots up.
 
+The full set of track maps that are supported is [here](README-tracks.md)
+When you make changes to the tracks.yaml file the new track map is automatically created and the readme page is updated.
+
+
 ## Technical Road Map
 
   We hope to put this system to the test in April 2021 at Sonoma Raceway at the 24 hours of lemons Sears Pointless race. We will see how ready we are, and how COVID affected the race is. But it gives us a deadline to get things operating.

--- a/lemon_pi/utils/html_to_image.py
+++ b/lemon_pi/utils/html_to_image.py
@@ -4,26 +4,27 @@ import asyncio
 import time
 from pyppeteer import launch
 
-if len(sys.argv) != 2:
+if len(sys.argv) < 2:
     print("usage : [filename.html]")
     sys.exit(1)
 
-file = sys.argv[1]
-outfile = file.replace(".html", ".jpg")
+files = sys.argv[1:]
 
 
-async def main():
+async def main(files:[]):
     browser = await launch()
     page = await browser.newPage()
-    await page.goto('https://storage.googleapis.com/perplexus/public/{}'.format(file))
-    # we need to wait for the background to load
-    time.sleep(1)
-    await page.screenshot({'path': outfile, 'fullPage': 'false',
-                           'type': 'jpeg', 'quality': 50,
-                           'clip' : {
-                               'x': 0, 'y': 0,
-                               'width': 600, 'height': 600
-                           }})
+    for file in files:
+        outfile = file.replace(".html", ".jpg")
+        await page.goto('https://storage.googleapis.com/perplexus/public/{}'.format(file))
+        # we need to wait for the background to load
+        time.sleep(1)
+        await page.screenshot({'path': outfile, 'fullPage': 'false',
+                               'type': 'jpeg', 'quality': 50,
+                               'clip' : {
+                                   'x': 0, 'y': 0,
+                                   'width': 600, 'height': 600
+                               }})
     await browser.close()
 
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.get_event_loop().run_until_complete(main(files))

--- a/lemon_pi/utils/image_crop.py
+++ b/lemon_pi/utils/image_crop.py
@@ -1,0 +1,25 @@
+
+import sys
+import os
+from PIL import Image
+
+
+def crop(file):
+    im:Image.Image = Image.open(file)
+    width, height = im.size
+
+    print('original size = {},{}'.format(width, height))
+
+    crop = im.crop((32, 51, width - 64, height - 100))
+
+    file, ext = os.path.splitext(file)
+    crop.save("{}-clipped.jpg".format(file), "JPEG")
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("need a filename")
+        sys.exit(0)
+
+    file = sys.argv[1]
+    crop(file)
+

--- a/lemon_pi/utils/plot_tracks.py
+++ b/lemon_pi/utils/plot_tracks.py
@@ -27,7 +27,7 @@ def run():
 
     for track in tracks:
         mid_lat, mid_long = _calc_mid(track)
-        gmap = gmplot.GoogleMapPlotter(mid_lat, mid_long, 16,
+        gmap = gmplot.GoogleMapPlotter(mid_lat, mid_long, 14,
                                        map_type="satellite",
                                        title=track.get_display_name())
         gmap.apikey = os.environ["GMAP_APIKEY"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,10 @@ guizero==1.1.1
 haversine==2.3.0
 numpy==1.19.4
 obd==0.7.1
+Pillow==8.1.0
 Pint==0.7.2
 protobuf==3.14.0
+pyppeteer==0.2.5
 pyserial==3.5
 python-dateutil==2.8.1
 python-settings==0.2.2


### PR DESCRIPTION
clips images and makes them smaller
stops using markdown on the tracks page and just uses anchors and images the good ol fashioned way
speeds up html image generation by doing them all in one launch rather than relaunching for each image

adds pypeteer and pillow to required libraries