### PR TITLE
fixes up the leaderboard code 

### DIFF
--- a/lemon_pi/pit/datasource/datasource_handler.py
+++ b/lemon_pi/pit/datasource/datasource_handler.py
@@ -23,11 +23,13 @@ class DataSourceHandler:
                             self.race_flag = bits[5].strip('" ')
                             RaceStatusEvent.emit(flag=self.race_flag)
                     if bits[0] == "$G" and len(bits) == 5:
+                        # "$G" indicates a cars position and number of laps completed
                         # print(bits)
                         car_number = bits[2].strip('"')
-                        self.leaderboard.update_position(car_number, int(bits[1]))
+                        laps_completed = None
                         if bits[3].isnumeric():
-                            self.leaderboard.update_lap_count(car_number, int(bits[3]))
+                            laps_completed = int(bits[3])
+                        self.leaderboard.update_position(car_number, int(bits[1]), laps_completed)
                     if bits[0] == "$H" and len(bits) == 5:
                         # print(bits)
                         car_number = bits[2].strip('"')

--- a/lemon_pi/pit/event_defs.py
+++ b/lemon_pi/pit/event_defs.py
@@ -42,3 +42,6 @@ TelemetryEvent = Event("telemetry")
 #   car=
 #   msg=
 SendMessageEvent = Event("send-message")
+
+# dumo out the leaderboard to stdout
+DumpLeaderboardEvent = Event("dump-leaderboard")

--- a/lemon_pi/pit/gui.py
+++ b/lemon_pi/pit/gui.py
@@ -8,7 +8,7 @@ from lemon_pi.pit.event_defs import (
     RaceStatusEvent,
     PittingEvent,
     LapCompletedEvent,
-    TelemetryEvent
+    TelemetryEvent, DumpLeaderboardEvent
 )
 from lemon_pi.shared.events import Event
 from lemon_pi.shared.time_provider import TimeProvider
@@ -115,6 +115,9 @@ class Gui():
                                      last_lap_fuel=312 + presses,
                                      fuel_percent=98 - presses)
             presses += 1
+
+        if event_data.key == 'd':
+            DumpLeaderboardEvent.emit()
 
     def create_temp_gauge(self, parent, grid):
         result = Box(parent, grid=grid)

--- a/lemon_pi/pit/main.py
+++ b/lemon_pi/pit/main.py
@@ -48,10 +48,14 @@ def run():
         gui.progress(40)
 
         # start the radio thread
-        radio = Radio(settings.RADIO_DEVICE, settings.RADIO_KEY)
-        RadioInterface(radio)
-        radio.start()
-        gui.progress(85)
+        try:
+            radio = Radio(settings.RADIO_DEVICE, settings.RADIO_KEY)
+            RadioInterface(radio)
+            radio.start()
+            gui.progress(85)
+        except KeyError:
+            print("ERROR : Lora radio device not detected")
+            gui.shutdown()
 
         # if we have a race specified
         if settings.RACE_ID != "":

--- a/lemon_pi/pit/tests/datasource_handler_test.py
+++ b/lemon_pi/pit/tests/datasource_handler_test.py
@@ -37,6 +37,24 @@ class DatasourceHandlerTestCase(unittest.TestCase):
             for line in f.readlines():
                 dsh.handle_message(line)
         self.assertEqual("160", ro.first.car_number)
+        ro.__check_data_structure__()
+
+    # will leave this as a manual test that can be run as the data file is
+    # elsewhere and is very large
+    # def test_luckydog(self):
+    #     ro = RaceOrder()
+    #     dsh = DataSourceHandler(ro, "125")
+    #     with open('/Users/paulnormington/src/rpi/base-station/capture-102308.dat') as f:
+    #         last_line = ""
+    #         for line in f.readlines():
+    #             dsh.handle_message(line)
+    #             print("handled '{}'".format(line))
+    #             if line.startswith("$RMS"):
+    #                 ro.__check_data_structure__()
+    #             if line.startswith("$F") and last_line.startswith("$F"):
+    #                 ro.__check_data_structure__()
+    #             last_line = line
+    #     print(ro)
 
 
 test_file = """

--- a/lemon_pi/pit/tests/leaderboard_test.py
+++ b/lemon_pi/pit/tests/leaderboard_test.py
@@ -15,7 +15,7 @@ class LeaderboardTestCase(unittest.TestCase):
         self.assertTrue(race.__check_data_structure__())
         self.assertEqual(1, race.size())
         # start the race
-        race.update_position("181", 1)
+        race.update_position("181", 1, 1)
         self.assertTrue(race.__check_data_structure__())
 
     def test_race_with_two_cars(self):
@@ -25,7 +25,7 @@ class LeaderboardTestCase(unittest.TestCase):
         self.assertTrue(race.__check_data_structure__())
         self.assertEqual(2, race.size())
         # start the race
-        race.update_position("181", 1)
+        race.update_position("181", 1, 1)
         self.assertTrue(race.__check_data_structure__())
 
     def test_two_cars_other_order(self):
@@ -35,9 +35,10 @@ class LeaderboardTestCase(unittest.TestCase):
         self.assertTrue(race.__check_data_structure__())
         self.assertEqual(2, race.size())
         # start the race
-        race.update_position("181", 1)
+        race.update_position("181", 1, 1)
         self.assertTrue(race.__check_data_structure__())
-        self.assertPositions(race, ["181", "180"])
+        self.assertPositions(race, ["181"])
+        self.assertEqual(CarPosition.NOT_STARTED, race.first.car_behind.position)
 
     def test_race_with_multiple_cars(self):
         race = RaceOrder()
@@ -47,11 +48,11 @@ class LeaderboardTestCase(unittest.TestCase):
         self.assertTrue(race.__check_data_structure__())
         self.assertEqual(3, race.size())
         # start the race
-        race.update_position("181", 1)
+        race.update_position("181", 1, 1)
         self.assertTrue(race.__check_data_structure__())
-        race.update_position("180", 2)
+        race.update_position("180", 2, 1)
         self.assertTrue(race.__check_data_structure__())
-        race.update_position("183", 3)
+        race.update_position("183", 3, 1)
         self.assertTrue(race.__check_data_structure__())
         self.assertPositions(race, ["181", "180", "183"])
 
@@ -63,18 +64,18 @@ class LeaderboardTestCase(unittest.TestCase):
         race.add_car(CarPosition("2", "Cervesa"))
         race.add_car(CarPosition("999", "Non-starter"))
 
-        race.update_position("2", 1)
-        race.update_position("180", 2)
-        race.update_position("183", 3)
-        race.update_position("181", 4)
+        race.update_position("2", 1, 1)
+        race.update_position("180", 2, 1)
+        race.update_position("183", 3, 1)
+        race.update_position("181", 4, 1)
 
         self.assertTrue(race.__check_data_structure__())
 
         # lap 2 happens and there a big overtake
-        race.update_position("181", 1)
-        race.update_position("2", 2)
-        race.update_position("180", 3)
-        race.update_position("183", 4)
+        race.update_position("181", 1, 2)
+        race.update_position("2", 2, 2)
+        race.update_position("180", 3, 2)
+        race.update_position("183", 4, 2)
         self.assertTrue(race.__check_data_structure__())
         self.assertPositions(race, ["181", "2", "180", "183"])
 
@@ -88,10 +89,10 @@ class LeaderboardTestCase(unittest.TestCase):
 
         # when race data arrives as we join partway through a race the
         # entries come in out of sequential order
-        race.update_position("180", 3)
-        race.update_position("2", 4)
-        race.update_position("183", 2)
-        race.update_position("181", 1)
+        race.update_position("180", 3, 4)
+        race.update_position("2", 4, 4)
+        race.update_position("183", 2, 5)
+        race.update_position("181", 1, 6)
 
         self.assertTrue(race.__check_data_structure__())
         self.assertPositions(race, ["181", "183", "180", "2"])

--- a/lemon_pi/shared/protos/messages.proto
+++ b/lemon_pi/shared/protos/messages.proto
@@ -42,6 +42,7 @@ enum RaceFlagStatus {
   YELLOW = 2;
   RED = 3;
   BLACK = 4;
+  FINISH = 5;
 }
 
 // the race status. Only sent when it changes


### PR DESCRIPTION
after using the system for reals against a live race, it became apparent that we should not rely on the position in the race that is passed to us. Instead we should use the number of laps completed that are passed to us, and order everything by number of laps.

Once we have added entries by laps completed, we then traverse the list from 1st to last numbering each element.

This could be optimized, but we're not going to get too excited about that right now.