### PR TITLE
allow remote fuel level to be reset from pit

### DIFF
--- a/lemon_pi/car/event_defs.py
+++ b/lemon_pi/car/event_defs.py
@@ -39,6 +39,7 @@ GPSConnectedEvent = Event("GPS-Connected")
 GPSDisconnectedEvent = Event("GPS-Disconnected")
 
 ### Refuel event
+# percent_full=
 RefuelEvent = Event("Refuel")
 
 ### Car has come to a halt

--- a/lemon_pi/car/radio_interface.py
+++ b/lemon_pi/car/radio_interface.py
@@ -11,7 +11,7 @@ from lemon_pi.car.event_defs import (
     DriverMessageEvent,
     DriverMessageAddendumEvent,
     RaceFlagStatusEvent,
-    LapInfoEvent, RadioReceiveEvent
+    LapInfoEvent, RadioReceiveEvent, RefuelEvent
 )
 from lemon_pi.shared.events import EventHandler
 from lemon_pi.shared.generated.messages_pb2 import (
@@ -21,7 +21,7 @@ from lemon_pi.shared.generated.messages_pb2 import (
     Ping,
     RacePosition,
     EnteringPits,
-    RaceFlagStatus)
+    RaceFlagStatus, SetFuelLevel)
 
 from python_settings import settings
 
@@ -118,6 +118,12 @@ class RadioInterface(Thread, EventHandler):
             # it's more for corrective purposes, so the display doesn't get stuck in a bad
             # state if a flag message is missed
             RaceFlagStatusEvent.emit(flag=RaceFlagStatus.Name(msg.flag_status))
+        elif type(msg) == SetFuelLevel:
+            logger.info("got fuel level adjustment...{}".format(msg))
+            if msg.percent_full == 0:
+                RefuelEvent.emit(percent_full=100)
+            else:
+                RefuelEvent.emit(percent_full=msg.percent_full)
         else:
             logger.warning("got unexpected message : {}".format(type(msg)))
 

--- a/lemon_pi/car/state_machine.py
+++ b/lemon_pi/car/state_machine.py
@@ -39,7 +39,7 @@ class StateMachine(EventHandler):
                 StateChangeSettingOffEvent.emit()
                 return
             if event == OBDConnectedEvent:
-                RefuelEvent.emit()
+                RefuelEvent.emit(percent_full=100)
                 return
 
         if self.state == State.ON_TRACK:

--- a/lemon_pi/car/tests/maf_analyzer_test.py
+++ b/lemon_pi/car/tests/maf_analyzer_test.py
@@ -1,5 +1,6 @@
 import unittest
 
+from lemon_pi.car.event_defs import RefuelEvent
 from lemon_pi.car.maf_analyzer import MafAnalyzer
 
 from python_settings import settings
@@ -13,13 +14,24 @@ class MafTestCase(unittest.TestCase):
 
     def test_initial_fuel_remaining(self):
         ma = MafAnalyzer(None)
-        self.assertEqual(-1, ma.get_fuel_percent_remaining())
+        self.assertEqual(100, ma.get_fuel_percent_remaining())
 
     def test_no_fuel_remaining(self):
         ma = MafAnalyzer(None)
         ma.total_fuel_used_ml = 10.5 * 3785
         self.assertEqual(0, ma.get_fuel_percent_remaining())
 
+    def test_refuel_100(self):
+        ma = MafAnalyzer(None)
+        ma.total_fuel_used_ml = 10000
+        ma.handle_event(RefuelEvent, percent_full=100)
+        self.assertEqual(100, ma.get_fuel_percent_remaining())
+
+    def test_refuel_25(self):
+        ma = MafAnalyzer(None)
+        ma.total_fuel_used_ml = 10000
+        ma.handle_event(RefuelEvent, percent_full=25)
+        self.assertEqual(25, ma.get_fuel_percent_remaining())
 
 if __name__ == '__main__':
     unittest.main()

--- a/lemon_pi/car/tests/radio_interface_test.py
+++ b/lemon_pi/car/tests/radio_interface_test.py
@@ -1,0 +1,26 @@
+import unittest
+from unittest.mock import patch
+
+from lemon_pi.car.radio_interface import RadioInterface
+from lemon_pi.shared.generated.messages_pb2 import SetFuelLevel
+
+
+class RadioInterfaceTestCase(unittest.TestCase):
+
+    @patch("lemon_pi.car.event_defs.RefuelEvent.emit")
+    def test_refuel_message(self, refuel_event):
+        ri = RadioInterface(None, None, None, None)
+        ri.process_incoming(SetFuelLevel())
+        refuel_event.assert_called_with(percent_full=100)
+
+    @patch("lemon_pi.car.event_defs.RefuelEvent.emit")
+    def test_refuel_message_with_percent(self, refuel_event):
+        ri = RadioInterface(None, None, None, None)
+        sf = SetFuelLevel()
+        sf.percent_full = 69
+        ri.process_incoming(sf)
+        refuel_event.assert_called_with(percent_full=69)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lemon_pi/car/tests/radio_interface_test.py
+++ b/lemon_pi/car/tests/radio_interface_test.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 from lemon_pi.car.radio_interface import RadioInterface
 from lemon_pi.shared.generated.messages_pb2 import SetFuelLevel
@@ -9,13 +9,13 @@ class RadioInterfaceTestCase(unittest.TestCase):
 
     @patch("lemon_pi.car.event_defs.RefuelEvent.emit")
     def test_refuel_message(self, refuel_event):
-        ri = RadioInterface(None, None, None, None)
+        ri = RadioInterface(Mock(), None, None, None)
         ri.process_incoming(SetFuelLevel())
         refuel_event.assert_called_with(percent_full=100)
 
     @patch("lemon_pi.car.event_defs.RefuelEvent.emit")
     def test_refuel_message_with_percent(self, refuel_event):
-        ri = RadioInterface(None, None, None, None)
+        ri = RadioInterface(Mock(), None, None, None)
         sf = SetFuelLevel()
         sf.percent_full = 69
         ri.process_incoming(sf)

--- a/lemon_pi/shared/protos/messages.proto
+++ b/lemon_pi/shared/protos/messages.proto
@@ -117,6 +117,16 @@ message EnteringPits {
 
 }
 
+message SetFuelLevel {
+  int32 seq_num = 1;
+
+  int32 timestamp = 2;
+
+  string sender = 3;
+
+  int32 percent_full = 4;
+}
+
 //  ********************
 //  **** IMPORTANT *****
 //  ********************

--- a/lemon_pi/shared/radio_message.py
+++ b/lemon_pi/shared/radio_message.py
@@ -6,7 +6,7 @@ from lemon_pi.shared.generated.messages_pb2 import (
     RaceStatus,
     RacePosition,
     CarTelemetry,
-    EnteringPits)
+    EnteringPits, SetFuelLevel)
 
 
 class ProtobufEnum(Enum):
@@ -16,6 +16,8 @@ class ProtobufEnum(Enum):
    RacePosition = 3
    CarTelemetry = 4
    EnteringPits = 5
+   SetFuelLevel = 6
+   # Add next item here AND fill in if statement below (seems lame)
 
 class UnknownRadioMessage(Exception):
     pass
@@ -34,6 +36,8 @@ def create_instance(msg:ProtobufEnum):
         return CarTelemetry()
     elif msg == ProtobufEnum.EnteringPits:
         return EnteringPits()
+    elif msg == ProtobufEnum.SetFuelLevel:
+        return SetFuelLevel()
     raise UnknownRadioMessage()
 
 

--- a/lemon_pi/shared/tests/message_encoder_test.py
+++ b/lemon_pi/shared/tests/message_encoder_test.py
@@ -3,7 +3,7 @@ import unittest
 from lemon_pi.shared.message_encoder import MessageEncoder
 from lemon_pi.shared.message_decoder import MessageDecoder
 
-from lemon_pi.shared.generated.messages_pb2 import Ping
+from lemon_pi.shared.generated.messages_pb2 import Ping, SetFuelLevel
 
 
 class EncoderTestCase(unittest.TestCase):
@@ -17,6 +17,16 @@ class EncoderTestCase(unittest.TestCase):
         ping = m.decode(payload)
         self.assertEqual("car-180", ping.sender)
         self.assertEqual(1, ping.seq_num)
+
+    def test_refuel_roundtrip(self):
+        e = MessageEncoder("car-180", "letmein")
+        orig = SetFuelLevel()
+        payload = e.encode(orig)
+
+        m = MessageDecoder("letmein")
+        fuel = m.decode(payload)
+        self.assertEqual("car-180", fuel.sender)
+        self.assertEqual(1, fuel.seq_num)
 
 
 if __name__ == '__main__':

--- a/lemon_pi/utils/send_fuel_level.py
+++ b/lemon_pi/utils/send_fuel_level.py
@@ -1,0 +1,39 @@
+
+import os
+import sys
+import logging
+import time
+from python_settings import settings
+
+from lemon_pi.shared.generated.messages_pb2 import (
+    SetFuelLevel
+)
+from lemon_pi.shared.radio import Radio
+from lemon_pi.shared.usb_detector import UsbDetector
+
+logger = logging.getLogger(__name__)
+
+logging.basicConfig(format='%(asctime)s %(name)s %(message)s',
+                    datefmt='%Y-%m-%d %H:%M:%S',
+                    level=logging.INFO)
+
+if not "SETTINGS_MODULE" in os.environ:
+    os.environ["SETTINGS_MODULE"] = "lemon_pi.config.local_settings_pit"
+
+if len(sys.argv) != 2:
+    print("usage : {} [0-100]".format(__file__))
+    sys.exit(1)
+
+UsbDetector().init()
+
+radio = Radio(settings.RADIO_DEVICE, settings.RADIO_KEY)
+radio.start()
+
+msg = SetFuelLevel()
+msg.percent_full = int(sys.argv[1])
+
+radio.send_async(msg)
+
+logger.info("sleeping to give transmission enough time")
+time.sleep(5)
+logger.info("finished")


### PR DESCRIPTION
Introduces a protobuf message to transmit a message from the pit to the car to reset the fuel level.
By default the fuel level is reset back to full.
It can have any percentage value from 1-100 set

A utility has been added that can be run from the command line if this ever had to be used.
We could put this into the pit UI, but I think it might get hit accidentally.