### PR TITLE
OBD improvements

### DIFF
--- a/lemon_pi/car/obd_reader.py
+++ b/lemon_pi/car/obd_reader.py
@@ -1,6 +1,7 @@
 import obd
 from obd import OBDResponse
 import time
+import os
 import logging
 import platform
 
@@ -15,26 +16,29 @@ from lemon_pi.shared.usb_detector import UsbDetector, UsbDevice
 logger = logging.getLogger(__name__)
 
 
-##
-##  useful reading : https://www.autoserviceprofessional.com/articles/6237-fuel-trim-how-it-works-and-how-to-make-it-work-for-you
-##
-## Fuel mass = Air mass x (short-term fuel trim x long-term fuel trim) divided by (equivalence ratio x 14.64)
-##
-## Although, I add the short and long term fuel trims together as it makes more sense (to me)
-##
+#
+#  useful reading : https://www.autoserviceprofessional.com/articles/6237-fuel-trim-how-it-works-and-how-to-make-it-work-for-you
+#
+# Fuel mass = Air mass x (short-term fuel trim x long-term fuel trim) divided by (equivalence ratio x 14.64)
+#
+# Although, I add the short and long term fuel trims together as it makes more sense (to me)
+#
 class ObdReader(Thread, TemperatureProvider):
 
     refresh_rate = {
         obd.commands.COOLANT_TEMP: 10,
-        obd.commands.LONG_FUEL_TRIM_1: 10,
-        obd.commands.SHORT_FUEL_TRIM_1: 0.1,
-        obd.commands.MAF: 0.1,
+#        obd.commands.FUEL_STATUS: 1,
+#        obd.commands.LONG_FUEL_TRIM_1: 10,
+#        obd.commands.SHORT_FUEL_TRIM_1: 0.1,
+        obd.commands.MAF: 0.2,
     }
 
     def __init__(self, fuel_listener: FuelUsageUpdater):
         Thread.__init__(self)
         self.working = False
         self.temp_f = 0
+        # the time the temperature was last read from OBD
+        self.temp_time = 0
         self.short_term_fuel_trim = 0.0
         self.long_term_fuel_trim = 0.0
         self.last_update_time = {}
@@ -51,41 +55,55 @@ class ObdReader(Thread, TemperatureProvider):
             self.finished = True
 
     def run(self) -> None:
+        connection = None
         while not self.finished:
             try:
-                connection = self.connect()
+                connection = self.connect(connection)
                 if connection is None:
                     time.sleep(30)
                     continue
 
                 while connection.status() == obd.OBDStatus.CAR_CONNECTED and not self.finished:
                     now = time.time()
-                    for cmd in ObdReader.refresh_rate.keys() :
+                    for cmd in ObdReader.refresh_rate.keys():
                         if now - self.last_update_time[cmd] > ObdReader.refresh_rate[cmd]:
                             r = connection.query(cmd)
-                            if r is not None:
+                            if not r.is_null():
                                 self.working = True
                                 self.last_update_time[cmd] = r.time
                                 self.process_result(cmd, r)
                     # I think we need MAF as fast as poss
-                    #time.sleep(1)
+                    # time.sleep(1)
             except Exception as e:
                 logger.exception("bad stuff in OBD land %s", e)
+                if connection:
+                    connection.close()
                 self.working = False
                 OBDDisconnectedEvent.emit()
                 time.sleep(10)
 
-    def connect(self):
+    @staticmethod
+    def connect(old_connection):
         port = UsbDetector.get(UsbDevice.OBD)
         if not port:
             return None
 
-        result = obd.OBD(port, protocol=settings.OBD_PROTOCOL)
+        if old_connection:
+            OBDDisconnectedEvent.emit()
+            old_connection.close()
+
+        result = obd.OBD(port, protocol=settings.OBD_PROTOCOL, fast=True)
         status = result.status()
         if status != obd.OBDStatus.CAR_CONNECTED:
             result.close()
             return None
-        OBDConnectedEvent.emit()
+
+        time.sleep(0.5)
+
+        cmds = result.query(obd.commands.PIDS_A)
+        if cmds.value:
+            logger.debug("available PIDS_A commands {}".format(cmds.value))
+            OBDConnectedEvent.emit()
 
         return result
 
@@ -95,6 +113,7 @@ class ObdReader(Thread, TemperatureProvider):
         logger.debug("processing {} at {}".format(cmd, response))
         if cmd == obd.commands.COOLANT_TEMP:
             self.temp_f = int(response.value.to('degF').magnitude)
+            self.temp_time = response.time
         elif cmd == obd.commands.MAF:
             fuel_usage = self.calc_fuel_rate(response.value.to('gps').magnitude,
                                              settings.FUEL_FIDDLE_PERCENT)
@@ -105,10 +124,15 @@ class ObdReader(Thread, TemperatureProvider):
         elif cmd == obd.commands.LONG_FUEL_TRIM_1:
             if response.value:
                 self.long_term_fuel_trim = response.value.magnitude
+        elif cmd == obd.commands.FUEL_STATUS:
+            pass
+
         else:
             raise RuntimeWarning("no handler for {}".format(cmd))
 
     def get_temp_f(self) -> int:
+        if time.time - self.temp_time > 60:
+            return -1
         return self.temp_f
 
     def is_working(self) -> bool:
@@ -124,17 +148,20 @@ class ObdReader(Thread, TemperatureProvider):
             ml_per_second += adjustment
         return ml_per_second
 
+
 if __name__ == "__main__":
+
+    if "SETTINGS_MODULE" not in os.environ:
+        os.environ["SETTINGS_MODULE"] = "lemon_pi.config.local_settings_car"
 
     logging.basicConfig(format='%(asctime)s %(name)s %(message)s',
                         datefmt='%Y-%m-%d %H:%M:%S',
-                        level=logging.INFO)
+                        level=logging.DEBUG)
 
     class OBDLogger(FuelUsageUpdater):
 
-        def update_fuel(self, ml_per_second:float, time:float):
+        def update_fuel(self, ml_per_second: float, time: float):
             print("Fuel: {:.2f} ml per sec".format(ml_per_second))
 
     UsbDetector.init()
     ObdReader(OBDLogger()).run()
-

--- a/lemon_pi/shared/gui_components.py
+++ b/lemon_pi/shared/gui_components.py
@@ -28,7 +28,12 @@ class AlertBox(Box):
         self.error_value = error
 
     def update_value(self, value:int):
-        self.children[1].value = str(value)
+        # a value of -1 is returned if the temperate is more than
+        # a minute old
+        if value > 0:
+            self.children[1].value = str(value)
+        else:
+            self.children[1].value = '?'
         if value < self.low_value:
             self._low()
         elif value < self.warn_value:


### PR DESCRIPTION
improve accuracy of OBD by reconnecting faster, switching to fast data requests.

Also experimenting with disabling fuel trim data, as it is only used when the
fuel status is in open loop mode and the O2 sensors are providing tuning. The car is
going to spend all its heavy fuel usage time in closed loop mode.

Switching maf fetching to 5 times per second ... we only got 3 per second at best before.

Trying fast fetching to see what difference that makes

Also attempts to clean up the connection to the serial OBD port on error a little better.
Improves accuracy of disconnect/connect graphics