### PR TITLE
support reversing the track

### DIFF
--- a/lemon_pi/car/tests/track_test.py
+++ b/lemon_pi/car/tests/track_test.py
@@ -1,10 +1,26 @@
 import re
 import unittest
-from lemon_pi.car.track import read_tracks, TrackLocation
+from lemon_pi.car.track import read_tracks, TrackLocation, swap_direction, do_read_tracks, START_FINISH, PIT_OUT, \
+    PIT_ENTRY
 from haversine import haversine, Unit
 
 
 class TrackTestCase(unittest.TestCase):
+
+    def test_change_heading(self):
+        self.assertEquals(180, swap_direction(0))
+        self.assertEquals(225, swap_direction(45))
+        self.assertEquals(270, swap_direction(90))
+        self.assertEquals(0, swap_direction(180))
+        self.assertEquals(90, swap_direction(270))
+
+    def test_read_test_file(self):
+        tracks: [TrackLocation] = do_read_tracks("resources/test/test-tracks.yaml")
+        test_track = next(filter(lambda track: track.name == "Arlington Test Track", tracks), None)
+        self.assertTrue(test_track.is_reversed())
+        self.assertAlmostEquals(330.1, test_track.targets[START_FINISH].target_heading, places=1)
+        self.assertAlmostEquals(134.9, test_track.targets[PIT_OUT].target_heading, places=1)
+        self.assertAlmostEquals(314.9, test_track.targets[PIT_ENTRY].target_heading, places=1)
 
     def test_read_tracks(self):
         tracks:[TrackLocation] = read_tracks()
@@ -29,8 +45,6 @@ class TrackTestCase(unittest.TestCase):
             self.assertTrue(pit_to_sf2 < 1)
 
         thunderhill = next(filter(lambda track: track.name == "Thunderhill", tracks), None)
-        self.assertTrue(thunderhill.is_radio_sync_defined())
-        self.assertEqual(2, len(thunderhill.get_radio_sync_targets()))
 
 if __name__ == '__main__':
     unittest.main()

--- a/resources/test/test-tracks.yaml
+++ b/resources/test/test-tracks.yaml
@@ -1,0 +1,13 @@
+tracks:
+  -  name: "Arlington Test Track"
+     code: "test1"
+     start_finish_coords: "(37.926223,-122.295029),(37.926291,-122.294879)"
+     start_finish_direction: "SE"
+     pit_entry_coords: "(37.928483,-122.297005),(37.928385,-122.297129)"
+     pit_entry_direction: "NW"
+     radio_sync_coords: "(37.927329,-122.296101),(37.927392,-122.295992)"
+     radio_sync_direction: "SE"
+     pit_out_coords: "(37.928483,-122.297005),(37.928385,-122.297129)"
+     pit_out_direction: "SE"
+     hidden: "true"
+     reversed: "true"

--- a/resources/tracks.yaml
+++ b/resources/tracks.yaml
@@ -26,13 +26,7 @@ tracks:
      pit_entry_direction: "S"
      pit_out_coords: "(39.539314,-122.331434),(39.539315,-122.331290)"
      pit_out_direction: "S"
-     radio_sync_list:
-       - "west cut":
-         radio_sync_coords: "(39.539930,-122.336541),(39.539739,-122.336530)"
-         radio_sync_direction: "E"
-       - "turn 8":
-         radio_sync_coords: "(39.545072,-122.332619),(39.544949,-122.332622)"
-         radio_sync_direction: "W"
+     reversed: "true"
 
   -  name: "Thunderhill West"
      code: "thilw"


### PR DESCRIPTION
This change allows the addition of an entry such as

  reversed: "true"

In the tracks.yaml file.  Reversing the track does the following:

1.  The start/finish direction is switched by 180 degrees
2. The pit-out gate is switched with the pit-in gate
3. The pit-out and pit-in gates have their direction switched by 180 degrees

In addition to the support for reversed tracks, Thunderhill is set as reversed.