### PR TITLE
obd : reconnect when no fresh data is arriving

### DIFF
--- a/lemon_pi/config/settings_car.py
+++ b/lemon_pi/config/settings_car.py
@@ -31,6 +31,7 @@ RADIO_CMD_COMPLETION_TIME = 0.1
 # protocol for OBD
 # see elm327.py for the list
 OBD_PROTOCOL = "3"
+OBD_FAST = True
 
 # temperature bands : display colorizes in these bands
 TEMP_BAND_LOW = 180


### PR DESCRIPTION
counts cycles when no data is arriving. After 5 consecutive cycles it reconnects itself. On the Lexus this appears to work nicely.

moves the FAST obd configuration into the config file (it had been hardcoded to be fast)