### PR TITLE
Several Improvements After Sonoma

### DIFF
--- a/lemon_pi/car/audio.py
+++ b/lemon_pi/car/audio.py
@@ -5,7 +5,8 @@ import logging
 from queue import Queue
 from threading import Thread
 
-from lemon_pi.car.event_defs import ButtonPressEvent, CompleteLapEvent, AudioAlarmEvent, RacePositionEvent
+from lemon_pi.car.event_defs import ButtonPressEvent, CompleteLapEvent, AudioAlarmEvent, RacePositionEvent, \
+    DriverMessageEvent
 from lemon_pi.shared.events import EventHandler
 
 logger = logging.getLogger(__name__)
@@ -40,6 +41,7 @@ class Audio(Thread, EventHandler):
         CompleteLapEvent.register_handler(self)
         AudioAlarmEvent.register_handler(self)
         RacePositionEvent.register_handler(self)
+        DriverMessageEvent.register_handler(self)
 
     def handle_event(self, event, **kwargs):
         if event == ButtonPressEvent:
@@ -53,6 +55,9 @@ class Audio(Thread, EventHandler):
             return
         if event == RacePositionEvent:
             self.announce_race_position(**kwargs)
+            return
+        if event == DriverMessageEvent:
+            self.announce(kwargs["text"])
             return
 
     def run(self) -> None:

--- a/lemon_pi/car/radio_interface.py
+++ b/lemon_pi/car/radio_interface.py
@@ -53,6 +53,7 @@ class RadioInterface(EventHandler):
         self.fuel_provider = fuel_provider
         RadioSyncEvent.register_handler(self)
         LeaveTrackEvent.register_handler(self)
+        EnterTrackEvent.register_handler(self)
 
     def register_lap_provider(self, lap_provider):
         self.lap_provider = lap_provider

--- a/lemon_pi/car/tests/audio_test.py
+++ b/lemon_pi/car/tests/audio_test.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 import time
 
 from lemon_pi.car.audio import Audio
-from lemon_pi.car.event_defs import ButtonPressEvent, CompleteLapEvent
+from lemon_pi.car.event_defs import ButtonPressEvent, CompleteLapEvent, DriverMessageEvent
 
 
 class TestAudio(unittest.TestCase):
@@ -49,6 +49,15 @@ class TestAudio(unittest.TestCase):
         self.assertEqual("100", Audio._car_number_to_audio("100"))
         self.assertEqual("seven O. seven", Audio._car_number_to_audio("707"))
         self.assertEqual("11b", Audio._car_number_to_audio("11b"))
+
+    def test_driver_message(self):
+        audio = Audio()
+        DriverMessageEvent.emit(text="pit in 3 laps")
+        self.assertEqual(1, audio.queue.qsize())
+        audio.engine.say = Mock()
+        audio.engine.runAndWait = Mock()
+        audio.run_once()
+        audio.engine.say.assert_called_with("pit in 3 laps")
 
 
 

--- a/lemon_pi/car/tests/radio_interface_test.py
+++ b/lemon_pi/car/tests/radio_interface_test.py
@@ -1,13 +1,34 @@
 import unittest
 from unittest.mock import patch, Mock
 
+from lemon_pi.car.event_defs import EnterTrackEvent, LeaveTrackEvent
 from lemon_pi.car.radio_interface import RadioInterface
-from lemon_pi_pb2 import SetFuelLevel, RaceStatus, SetTargetTime, ResetFastLap
+from lemon_pi_pb2 import SetFuelLevel, RaceStatus, SetTargetTime, ResetFastLap, ToPitMessage
 from race_flag_status_pb2 import RaceFlagStatus
 from lemon_pi.shared.tests.lemon_pi_test_case import LemonPiTestCase
 
 
 class RadioInterfaceTestCase(LemonPiTestCase):
+
+    @patch("lemon_pi.shared.meringue_comms.MeringueComms.send_message_from_car")
+    def test_entering_track(self, grpc_call):
+        comms = Mock()
+        comms.send_message_from_car = grpc_call
+        ri = RadioInterface(comms, None, None, None)
+        EnterTrackEvent.emit()
+        msg = ToPitMessage()
+        msg.entering.timestamp = 1
+        grpc_call.assert_called_with(msg)
+
+    @patch("lemon_pi.shared.meringue_comms.MeringueComms.send_message_from_car")
+    def test_leaving_track(self, grpc_call):
+        comms = Mock()
+        comms.send_message_from_car = grpc_call
+        ri = RadioInterface(comms, None, None, None)
+        LeaveTrackEvent.emit()
+        msg = ToPitMessage()
+        msg.pitting.timestamp = 1
+        grpc_call.assert_called_with(msg)
 
     @patch("lemon_pi.car.event_defs.RaceFlagStatusEvent.emit")
     def test_unknown_flag(self, race_status_event):


### PR DESCRIPTION
 * driver messages sent to lemon-pi will now play in the drivers ear, as well as displaying on screen
 * As you cross the line the race position shows .. until the predictive lap timer starts predicting
 * As a car following you crosses the line, the predictive lap timer disappears for 10s and the following car's gap is shown
 * As the car goes on track, this is sent to the cloud