### PR TITLE
allows small time adjustments to the DRS trigger points.

### DIFF
--- a/lemon_pi/car/gps_geometry.py
+++ b/lemon_pi/car/gps_geometry.py
@@ -74,12 +74,14 @@ def will_cross_line(this_pos: GpsPos, target: Target) -> (bool, float, bool):
     next_lat_long = get_point_on_heading((this_pos.lat, this_pos.long), this_pos.heading, miles_per_nearly2s)
     next_gps_point = GpsPos(next_lat_long[0], next_lat_long[1],
                             this_pos.heading, this_pos.speed, this_pos.timestamp + 1.8)
-    if this_pos.speed > 10:
-        logger.info(f"this gps point = {this_pos.lat},{this_pos.long} travelling at {miles_per_sec} mps")
-        logger.info(f"next gps point = {next_lat_long[0]},{next_lat_long[1]}")
-        dist1 = haversine((this_pos.lat, this_pos.long), target.midpoint, Unit.FEET)
-        dist2 = haversine(next_lat_long, target.midpoint, Unit.FEET)
-        logger.info(f"dist to this = {dist1}    dist to next = {dist2}")
+
+    # once useful for debugging
+    # if this_pos.speed > 10:
+    #     logger.debug(f"this gps point = {this_pos.lat},{this_pos.long} travelling at {miles_per_sec} mps")
+    #     logger.debug(f"next gps point = {next_lat_long[0]},{next_lat_long[1]}")
+    #     dist1 = haversine((this_pos.lat, this_pos.long), target.midpoint, Unit.FEET)
+    #     dist2 = haversine(next_lat_long, target.midpoint, Unit.FEET)
+    #     logger.debug(f"dist to this = {dist1}    dist to next = {dist2}")
 
     (crossed, cross_time, backwards) = crossed_line(this_pos, next_gps_point, target)
     if target.target_heading < 0:

--- a/lemon_pi/car/tests/drs_test.py
+++ b/lemon_pi/car/tests/drs_test.py
@@ -2,17 +2,51 @@ import time
 import unittest
 from unittest.mock import patch, MagicMock
 
-from lemon_pi.car.drs_controller import DrsDataLoader, DrsController
+from lemon_pi.car.drs_controller import DrsDataLoader, DrsController, DrsPositionTracker, DrsGate
 from lemon_pi.car.event_defs import DRSApproachEvent
 from lemon_pi.car.gps_geometry import will_cross_line
 from lemon_pi.car.target import Target
+from lemon_pi.car.track import TrackLocation, read_tracks
 from lemon_pi.shared.data_provider_interface import GpsPos
 
 
 class DrsFileLoadTest(unittest.TestCase):
 
     def test_loading_file(self):
-        DrsDataLoader().read_file("resources/drs_zones.json")
+        tracks: [TrackLocation] = read_tracks()
+        track_codes: set[str] = set(t.code for t in tracks)
+        loader = DrsDataLoader()
+        loader.read_file("resources/drs_zones.json")
+        for code, gates in loader.trackDrsZones.items():
+            self.assertTrue(code in track_codes)
+            # must be an even number of gates
+            self.assertTrue(len(gates) % 2 == 0)
+            for gate in gates:
+                # we can't have more than 1s time adjust
+                self.assertTrue(abs(gate.time_adjust) <= 1)
+
+
+class DrsTracker(unittest.TestCase):
+
+    @patch("lemon_pi.car.drs_controller.will_cross_line", return_value=(True, 1000, False))
+    @patch("lemon_pi.car.event_defs.DRSApproachEvent.emit")
+    def test_increased_delay(self, drs_event, _):
+        gate1 = DrsGate(0.99, 0.99, 1.001, 1.001, "test", True, +2)
+        gates = [gate1]
+        d = DrsPositionTracker(gates)
+        d.update_position(0.9990, 0.9990, 45, 1000, 100)
+        # we're asserting the delay is 2, which was specified in the gate
+        drs_event.assert_called_with(delay=2, activated=True, gate=gate1)
+
+    @patch("lemon_pi.car.drs_controller.will_cross_line", return_value=(True, 1000, False))
+    @patch("lemon_pi.car.event_defs.DRSApproachEvent.emit")
+    def test_decreased_delay(self, drs_event, _):
+        gate1 = DrsGate(0.99, 0.99, 1.001, 1.001, "test", True, -0.5)
+        gates = [gate1]
+        d = DrsPositionTracker(gates)
+        d.update_position(0.9990, 0.9990, 45, 1000, 100)
+        # we're asserting the delay is -0.5, which was specified in the gate
+        drs_event.assert_called_with(delay=-0.5, activated=True, gate=gate1)
 
 
 class DrsLineDetectionTest(unittest.TestCase):
@@ -29,17 +63,17 @@ class DrsLineDetectionTest(unittest.TestCase):
 class DrsControllerTest(unittest.TestCase):
 
     @patch('lemon_pi.shared.usb_detector.UsbDetector.detected', return_value=False)
-    def test_not_available(self, usb):
+    def test_not_available(self, _):
         d = DrsController()
         self.assertFalse(d.is_drs_available())
 
     @patch('lemon_pi.shared.usb_detector.UsbDetector.detected', return_value=True)
-    def test_available(self, usb):
+    def test_available(self, _):
         d = DrsController()
         self.assertTrue(d.is_drs_available())
 
     @patch('lemon_pi.shared.usb_detector.UsbDetector.detected', return_value=True)
-    def test_handling_single_event(self, usb):
+    def test_handling_single_event(self, _):
         d = DrsController()
         d.activate_drs = MagicMock()
         d.handle_event(DRSApproachEvent, delay=0.1, activated=True)
@@ -51,7 +85,7 @@ class DrsControllerTest(unittest.TestCase):
         d.activate_drs.assert_called_with(False)
 
     @patch('lemon_pi.shared.usb_detector.UsbDetector.detected', return_value=True)
-    def test_handling_sequence_of_events(self, usb):
+    def test_handling_sequence_of_events(self, _):
         d = DrsController()
         d.activate_drs = MagicMock()
         d.handle_event(DRSApproachEvent, delay=0.2, activated=True)


### PR DESCRIPTION
rather than having to edit the locations of DRS trigger points, this PR allows fine-tuning of the timing of trigger points.  Providing a negative time adjustment will effectively trigger DRS sooner. Providing a positive time adjustment delays the triggering.
The maximum time adjustment is +/- 1 second at any DRS gate